### PR TITLE
feat: Add initial capsule8 helm chart

### DIFF
--- a/incubator/capsule8/Chart.yaml
+++ b/incubator/capsule8/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: Capsule8 - Modernize without compromise.
+name: capsule8
+version: 0.1.0
+icon: https://avatars3.githubusercontent.com/u/22600059
+sources:
+  - https://github.com/capsule8/
+maintainers:
+  - name: Capsule8
+    email: info@capsule8.com

--- a/incubator/capsule8/README.md
+++ b/incubator/capsule8/README.md
@@ -1,0 +1,41 @@
+# Capsule8 Helm Chart
+
+This is a chart to install Capsule8 in a kubernetes cluster.
+
+## Install Helm
+
+A precursor to installing Capsule8 with [Helm](https://github.com/kubernetes/helm) is installing Helm itself. If you do not have Helm installed on the machine with which you will be connecting to your cluster, follow [the installation instructions](https://docs.helm.sh/using_helm/#installing-helm) followed by the [quickstart guide](https://docs.helm.sh/using_helm/#quickstart-guide) from Helm. This is an easy process where the binary for Helm is installed on the local machine which automatically uses the kubernetes configuration file to connect to the desired cluster.
+
+Once Helm is installed and has been initialized with the target cluster, it will be used to install Capsule8 in a single command.
+
+## Simple Installation
+
+The simplest version of a helm install of Capsule8 will be the following command.
+
+```
+helm install .
+```
+
+This command will take all of the default values in the `helm-chart/values.yaml` file and create all of the resources described in `helm-chart/templates`. Starting with that basic installation, any variations on the default values can be adjusted either in directly editing the `helm-chart/values.yaml` file, or at the command line as arguments. For most uses the bare default values will not be sufficient. At a minimum the `image` and `tag` values for most Capsule8 components will need to be set for a proper installation.
+
+## Setting Values at the Command Line
+
+When installing with values other than the default ones all that is needed is the name of the value and the `--set` argument.
+This example sets the sensor image as `my-docker/repository/capsule8-sensor:0.1.58`:
+
+```
+helm install . --set repository=my-docker/repository --set tag=0.1.58
+```
+
+### Release Naming
+
+The release name is the only exception to the `--set` convention. The release name is instead set by the `--name` flag. By default Helm sets a release name to every installation. If a release name is not explicitly set, Helm will auto generate a whimsical name involving animals and attributes. To install Capsule8 with the release name `my-name-capsule8` run the following:
+
+```bash
+helm install --name my-name .
+```
+
+### Capsule8 Values to Set
+
+When installing Capsule8 most values are taken care of and little additional configuration should be necessary. There are, however, a few sets of values which will need to be set either through the `helm-chart/values.yaml` file, or at the command line as arguments.
+

--- a/incubator/capsule8/templates/NOTES.txt
+++ b/incubator/capsule8/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Congratulations! You have successfully installed Capsule8.

--- a/incubator/capsule8/templates/_helpers.tpl
+++ b/incubator/capsule8/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/capsule8/templates/capsule8-console.yaml
+++ b/incubator/capsule8/templates/capsule8-console.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-console
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}-console
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}-console
+    spec:
+      containers:
+        - name: {{ template "fullname" . }}-console
+          image: "{{ .Values.repository }}/capsule8-console:{{ .Values.tag }}"
+          env:
+            - name: CAPSULE8_ADDRESS
+              value: "0.0.0.0:{{ .Values.console.addressPort }}"
+            - name: CAPSULE8_FRONTEND
+              value: "http://localhost:8080"
+            - name: CAPSULE8_MONITOR_PORT
+              value: "{{ .Values.console.monitoringPort }}"
+            - name: CAPSULE8_SERVER
+              value: {{ template "fullname" . }}-server:8484
+            - name: CAPSULE8_POSTGRES
+              value: postgresql://console:console@{{ template "fullname" . }}-postgres:5432/console?sslmode=disable
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.console.monitoringPort }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.console.monitoringPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-postgres
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}-postgres
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}-postgres
+    spec:
+      containers:
+        - name: {{ template "fullname" . }}-postgres
+          args:
+            - -c
+            - log_min_duration_statement=500
+          image: postgres:9.6.10-alpine
+          env:
+            - name: POSTGRES_USER
+              value: console
+            - name: POSTGRES_PASSWORD
+              value: console
+          ports:
+            - name: main
+              containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-server
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ template "name" . }}-postgre
+  ports:
+    - name: main
+      port: 5432

--- a/incubator/capsule8/templates/capsule8-sensor-config.yaml
+++ b/incubator/capsule8/templates/capsule8-sensor-config.yaml
@@ -1,0 +1,301 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-sensor-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  # the sensor configuration
+  capsule8-sensor.yaml : |
+    cloud_meta: auto
+    bundler:
+      events_per_message: 1
+    flight_recorder:
+      enabled: true
+      metaevents_whitelist:
+        - shell_command
+        - terminal_write
+        - boot_info
+        - node_metadata
+        - connection
+        - alert
+    investigations:
+      reporting_interval: 10s
+
+  # the capsule8 analytcs configuration that is mounted to the sensor containers
+  capsule8-analytics.yaml: |
+    print_meta_events: true
+    print_alerts: true
+
+    Production File Permissions:
+      policy: chmod
+      enabled: false
+      alertMessage: Permissions Modification Occurred
+      comments: Example strategy using the chmod policy
+      priority: Low
+      rules:
+      - ignore programName in $K8sChmodProgramsList
+      - default match
+      suid: true
+      sgid: true
+      svtx: true
+      rusr: true
+      wusr: true
+      xusr: true
+      rgrp: false
+      wgrp: false
+      xgrp: true
+      roth: false
+      woth: false
+      xoth: true
+
+    K8sChmodProgramsList:
+     type: paths
+     description: Whitelist of authorized programs
+     list:
+     - "docker-containerd-shim"
+     - "dockerd"
+     - "kubectl"
+     - "/proc/self/*"
+
+    Production SELinux:
+      policy: selinux
+      enabled: true
+      alertMessage: SELinux Disabled
+      priority: High
+      rules:
+      - default match
+      comments: Default SELinux Policy
+      default: false
+
+    DPKG Update Whitelist:
+      alertMessage: New File Executed
+      comments: New files should never be executed, this indicates potential compromise
+      enabled: true
+      fileTimeout: 30
+      policy: newFileExec
+      priority: High
+      rules:
+      - ignore programName == "/usr/bin/dpkg"
+      - ignore programName == "/usr/sbin/dpkg-preconfigure"
+      - ignore programName == "/var/lib/dpkg/tmp.ci/preinst"
+      - default match
+
+    Production Kernel Mode:
+      policy: smepSmap
+      enabled: true
+      alertMessage: SMEP/SMAP Disabled
+      priority: High
+      rules:
+      - default match
+      comments: Default SMEP/SMAP Policy
+
+    ThreatIntel Blacklist:
+      policy: connect
+      enabled: true
+      alertMessage: Unauthorized Network Connection
+      priority: Medium
+      rules:
+      - ignore containerName == "*kazoo*" and programName == "*/nc" and programArguments LIKE ".*[Ee][Xx][Pp][Ll][Oo][Ii][Tt]\.[Dd][Ee][Ll][Ii][Vv][Ee][Rr][Yy].*"
+      - match remoteHost == "54.231.113.250/32"
+      - default ignore
+      comments: Blacklist host 54.231.113.250
+
+    Userland Exploits:
+      policy: memoryProtection
+      enabled: true
+      alertMessage: Memory Protection Alert
+      priority: Medium
+      rules:
+      - default match
+      comments: Alerts on RWX memory allocations
+
+    Userland Exploit Attempts:
+      policy: segfault
+      enabled: true
+      alertMessage: Segmentation Fault Threshold
+      priority: Low
+      rules:
+      - default match
+      comments: Alerts when more than 20 segfaults occur in one minute
+      tolerance: 20
+      duration: 60.0
+
+    SSH Audit Trail:
+      policy: interactiveShell
+      enabled: true
+      alertMessage: Standard Interactive Shell Executed
+      priority: Low
+      rules:
+      - match parentProgramName == "/usr/sbin/sshd"
+      - default ignore
+      comments: Alerts on any interactive shell started by SSHD or docker-runc
+
+    Process Manipulation:
+      policy: ptrace
+      enabled: true
+      alertMessage: Ptrace Invoked
+      priority: High
+      rules:
+      - default match
+      comments: Alerts upon use of debug functions such as ptrace and process_vm_writev
+
+    Kernel Exploits:
+      policy: kernelPayload
+      enabled: true
+      alertMessage: Kernel Exploitation
+      priority: High
+      rules:
+      - ignore containerName == "*target2*"
+      - default match
+      comments: Alerts when a function unexpectedly returns to userland
+      extraLargeMemorySystems: false
+
+    Kernel Exploits Enforcing:
+      policy: kernelPayload
+      enabled: true
+      alertMessage: Kernel Exploitation
+      priority: High
+      rules:
+      - match containerName == "*target2*"
+      - default ignore
+      comments: Alerts when a function unexpectedly returns to userland
+      extraLargeMemorySystems: false
+      responseAction: kill
+
+    Credential Exploit:
+      policy: privilegeEscalation
+      enabled: true
+      alertMessage: Privilege Escalation Alert
+      priority: High
+      rules:
+      - default match
+      comments: Alerts when a program attempts to elevate privileges through unusual means
+
+    Non-standard Interactive Shell Policy:
+      policy: interactiveShell
+      enabled: true
+      alertMessage: Non-standard Interactive Shell Executed
+      priority: High
+      rules:
+        - ignore parentProgramName == "/usr/sbin/sshd"
+        - ignore parentProgramName == "/usr/bin/docker-runc" and containerName != ""
+        - ignore containerName == "*target2*"
+        - default match
+      comments: Alerts on any interactive shell not started by SSHD or docker-runc
+      alertOnIncompleteData: true
+
+    Enforcing Non-standard Interactive Shell Policy:
+      policy: interactiveShell
+      responseAction: kill
+      enabled: true
+      alertMessage: Non-standard Interactive Shell Executed
+      priority: Low
+      rules:
+        - ignore parentProgramName == "/usr/sbin/sshd"
+        - ignore parentProgramName == "/usr/bin/docker-runc"
+        - match containerName    == "*target2*"
+        - default ignore
+      comments: Alerts on any interactive shell not started by SSHD or docker-runc
+      alertOnIncompleteData: true
+
+    FIM Example:
+      policy: filemonitor
+      enabled: true
+      priority: Low
+      comments: Alert on any changes in /home/capsule8/example/*
+      alertMessage: Suspicious operation on file
+      rules:
+        - match filePath == "/home/capsule8/example/*"
+        - default ignore
+      responseAction: alert
+
+    AllowedServerPorts:
+      type: numbers
+      description: Only used for Bookmarker
+      list:
+        - 80
+
+    ServerWLExample:
+      policy: networkService
+      enabled: true
+      priority: High
+      comments: Generally auto-generate from a manifest
+      alertMessage: Disallowed network service
+      rules:
+    #    - ignore inboundHost == "127.0.0.0/8"
+        - ignore containerName != "*bookmarker*"
+        - ignore inboundPort in $AllowedServerPorts
+        - default match
+      responseAction: alert
+
+    Exempting Kazoo Daemon:
+      policy: filemonitor
+      enabled: true
+      priority: Low
+      comments: Exempts kazood from changes.
+      alertMessage: Suspicious operation on file
+      rules:
+        - ignore programName == "/usr/local/bin/klaunch" and programArguments == "klaunch /usr/local/bin/kazoo-server"
+        - ignore programName == "/usr/bin/python2.7" and programArguments == "klaunch /usr/local/bin/kazoo-server"
+        - match filePath == "/home/capsule8/example2/*"
+        - default ignore
+      responseAction: alert
+
+    Final Kazoo Policy:
+      policy: filemonitor
+      enabled: true
+      priority: Low
+      comments: Exempts kazood from changes.
+      alertMessage: Suspicious operation on file
+      rules:
+        - match  programName == "/usr/local/bin/klaunch" and parentProgramName == "/bin/bash" and filePath == "/home/capsule8/example3/*"
+        - match  programName == "/usr/bin/python2.7" and parentProgramName == "/bin/bash" and filePath == "/home/capsule8/example3/*"
+        - ignore programName == "/usr/local/bin/klaunch" and programArguments == "klaunch /usr/local/bin/kazoo-server"
+        - ignore programName == "/usr/bin/python2.7" and programArguments == "klaunch /usr/local/bin/kazoo-server"
+        - match filePath == "/home/capsule8/example3/*"
+        - default ignore
+      responseAction: alert
+
+    # STEP 1:
+    # a) Comment out WGET Blacklist 1 by adding # to the beginning of each line
+    # b) Uncomment WGET Blacklist 2 by removing the #'s (and nothing else) from each line
+    # c) Save the file, and exit.  The new configuration will load.
+
+    WGET Blacklist 1:
+      policy: program
+      enabled: true
+      alertMessage: Unauthorized Program Execution
+      priority: Medium
+      rules:
+      - match programName == "*/wget"
+      - default ignore
+      comments: Alert on usage of the wget command
+
+    #WGET Blacklist 2:
+    #  policy: program
+    #  enabled: true
+    #  alertMessage: Unauthorized Program Execution
+    #  priority: Medium
+    #  rules:
+    #  - ignore containerName == "*bookmarker*"
+    #  - match programName == "*/wget"
+    #  - default ignore
+    #  comments: Alert on usage of the wget command
+
+    # STEP 2:
+    # a) Comment out WGET Blacklist 2
+    # b) Comment in WGET Blacklist 3
+    # c) Save the file, and exit.
+
+    #WGET Blacklist 3:
+    #  policy: program
+    #  enabled: true
+    #  alertMessage: Unauthorized Program Execution
+    #  priority: Medium
+    #  rules:
+    #    - ignore containerName == "*capsule8-bookmarker*" and parentProgramArguments like "sh -c cd /webserver/public_html/; wget -r[/\\w\\d\.]*"
+    #    - match programName == "*/wget"
+    #    - default ignore
+    #  comments: Alert on usage of the wget command

--- a/incubator/capsule8/templates/capsule8-sensor.yaml
+++ b/incubator/capsule8/templates/capsule8-sensor.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}-sensor
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}-sensor
+  template:
+    metadata:
+      labels:
+        app: capsule8-sensor
+    spec:
+      hostPID: true
+      securityContext:
+        runAsUser: 0
+      containers:
+        - name: {{ template "fullname" . }}-sensor
+          image: "{{ .Values.repository }}/capsule8-sensor:{{ .Values.tag }}"
+          env:
+            - name: CAPSULE8_RUN_WITHOUT_SERVER
+              value: "false"
+            - name: CAPSULE8_NATS_URL
+              value: nats://{{ template "fullname" . }}-server:4222
+            - name: CAPSULE8_MONITOR_PORT
+              value: "{{ .Values.sensor.monitoringPort }}"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sensor.monitoringPort }}
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sensor.monitoringPort }}
+            initialDelaySeconds: 5
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              memory: 1Gi
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+              - SYS_ADMIN
+              - SYS_PTRACE
+              - KILL
+              - DAC_OVERRIDE
+              - IPC_LOCK
+              - FOWNER
+              - CHOWN
+          volumeMounts:
+            - name: capsule8-sensor-config
+              mountPath: /etc/capsule8
+            - name: cgroup
+              mountPath: /var/run/capsule8/mnt/sys/fs/cgroup
+              readOnly: true
+            - name: debugfs
+              mountPath: /var/run/capsule8/mnt/sys/kernel/debug
+            - name: proc
+              mountPath: /var/run/capsule8/mnt/proc
+              readOnly: true
+            - name: var-lib-docker
+              mountPath: /var/lib/docker
+              readOnly: true
+            - name: var-run-docker
+              mountPath: /var/run/docker
+              readOnly: true
+            - name: hostname
+              mountPath: /var/run/capsule8/mnt/hostname
+              readOnly: true
+      volumes:
+        - name: capsule8-sensor-config
+          configMap:
+            name: {{ template "fullname" . }}-sensor-config
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
+        - name: hostname
+          hostPath:
+            path: /etc/hostname
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: var-lib-docker
+          hostPath:
+            path: /var/lib/docker
+        - name: var-run-docker
+          hostPath:
+            path: /var/run/docker

--- a/incubator/capsule8/templates/capsule8-server.yaml
+++ b/incubator/capsule8/templates/capsule8-server.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-server
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}-server
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}-server
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+        - name: {{ template "fullname" . }}-server
+          image: "{{ .Values.repository }}/capsule8-server:{{ .Values.tag }}"
+          env:
+            - name: CAPSULE8_C8SQLDB_ENABLED
+              value: "true"
+            - name: CAPSULE8_C8SQLDB_DATABASE_DIR
+              value: "/var/lib/capsule8/flushed"
+            - name: CAPSULE8_AUTOMATIC_FLUSH_INTERVAL
+              value: "5m"
+            - name: CAPSULE8_MONITOR_PORT
+              value: "{{ .Values.server.monitoringPort }}"
+          ports:
+            - name: nats
+              containerPort: 4222
+            - name: nats-clustering
+              containerPort: 6222
+            - name: nats-monitoring
+              containerPort: 8222
+            - name: grpc
+              containerPort: 8484
+            - name: httpjson
+              containerPort: 8485
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.server.monitoringPort }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.server.monitoringPort }}
+          volumeMounts:
+            - name: var-lib-capsule8-configs
+              mountPath: /var/lib/capsule8/configs
+            - name: var-lib-capsule8-flushed
+              mountPath: /var/lib/capsule8/flushed
+            - name: var-run-capsule8
+              mountPath: /var/run/capsule8
+      volumes:
+        - name: var-lib-capsule8-configs
+          hostPath:
+            path: /var/lib/capsule8/configs
+        - name: var-lib-capsule8-flushed
+          emptyDir: {}
+        - name: var-run-capsule8
+          hostPath:
+            path: /var/run/capsule8
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-server
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: NodePort
+  selector:
+    app: {{ template "name" . }}-server
+  ports:
+    - name: nats
+      port: 4222
+    - name: nats-clustering
+      port: 6222
+    - name: nats-monitoring
+      port: 8222
+    - name: grpc
+      port: 8484
+    - name: httpjson
+      port: 8485

--- a/incubator/capsule8/templates/capsule8-shell.yaml
+++ b/incubator/capsule8/templates/capsule8-shell.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-shell
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}-shell
+    spec:
+      containers:
+        - name: {{ template "fullname" . }}-shell
+          image: "{{ .Values.repository }}/capsule8-shell:{{ .Values.tag }}"
+          stdin: true
+          tty: true
+          env:
+            - name: CAPSULE8_SERVER
+              value: {{ template "fullname" . }}-server:8484
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/incubator/capsule8/values.yaml
+++ b/incubator/capsule8/values.yaml
@@ -1,0 +1,20 @@
+# Default values for Capsule8
+
+# "repository" must be set to the local registry that contains the capsule8
+# images. The kubernetes cluster must also have pull access to this registry.
+repository: my-registry
+tag: 0.1.58
+
+# This installation assumes that whichever namespace is set here already exists.
+namespace: default
+
+server:
+  monitoringPort: 9011
+
+console:
+  mainPort: 9090
+
+sensor:
+  monitoringPort: 9010
+
+


### PR DESCRIPTION
This PR is a first pass at a capsule8 helm chart. It includes our most updated Capsule8 manifests and limited templating. There is definitely boilerplate here that needs to be updated and clarified. The manifests need to be integrated in the templating of the chart significantly more.

This is being set up for internal tooling to start using this chart so we can iterate and work on the chart and its use internally